### PR TITLE
feat: 신고 기능을 구현한다

### DIFF
--- a/src/main/java/com/atwoz/member/config/AuthConfig.java
+++ b/src/main/java/com/atwoz/member/config/AuthConfig.java
@@ -5,6 +5,7 @@ import com.atwoz.member.ui.auth.interceptor.ParseMemberIdFromTokenInterceptor;
 import com.atwoz.member.ui.auth.interceptor.PathMatcherInterceptor;
 import com.atwoz.member.ui.auth.interceptor.TokenRegenerateInterceptor;
 import com.atwoz.member.ui.auth.support.resolver.AuthArgumentResolver;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -12,7 +13,6 @@ import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import java.util.List;
 import static com.atwoz.member.ui.auth.interceptor.HttpMethod.DELETE;
 import static com.atwoz.member.ui.auth.interceptor.HttpMethod.GET;
 import static com.atwoz.member.ui.auth.interceptor.HttpMethod.OPTIONS;
@@ -52,7 +52,8 @@ public class AuthConfig implements WebMvcConfigurer {
                 .excludePathPattern("/**", OPTIONS)
                 .excludePathPattern("/api/missions/**", GET, POST, PATCH, DELETE)
                 .excludePathPattern("/api/surveys/**", GET, POST)
-                .addPathPatterns("/api/members/**", GET, POST, PATCH, DELETE);
+                .addPathPatterns("/api/members/**", GET, POST, PATCH, DELETE)
+                .addPathPatterns("/api/reports/**", POST);
     }
 
     private HandlerInterceptor tokenRegenerateInterceptor() {

--- a/src/main/java/com/atwoz/report/application/ReportService.java
+++ b/src/main/java/com/atwoz/report/application/ReportService.java
@@ -1,0 +1,40 @@
+package com.atwoz.report.application;
+
+import com.atwoz.report.application.dto.ReportCreateRequest;
+import com.atwoz.report.domain.Report;
+import com.atwoz.report.domain.ReportRepository;
+import com.atwoz.report.exception.exceptions.ReportNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+
+    public void createReport(final ReportCreateRequest reportCreateRequest, final Long reporterId) {
+        Report report = Report.createWith(reportCreateRequest.reportedUserId(), reporterId,
+                reportCreateRequest.reportTypeCode(), reportCreateRequest.content());
+
+        reportRepository.save(report);
+    }
+
+    public void updateReportResult(final String reportResult, final Long reportId) {
+        Report foundReport = findReportById(reportId);
+        foundReport.updateReportResult(reportResult);
+    }
+
+    private Report findReportById(final Long reportId) {
+        return reportRepository.findById(reportId)
+                .orElseThrow(ReportNotFoundException::new);
+    }
+
+    @Scheduled(cron = "0 31 0 * * ?")
+    public void deleteReport() {
+        reportRepository.deleteProcessedOldReports();
+    }
+}

--- a/src/main/java/com/atwoz/report/application/ReportService.java
+++ b/src/main/java/com/atwoz/report/application/ReportService.java
@@ -33,7 +33,7 @@ public class ReportService {
                 .orElseThrow(ReportNotFoundException::new);
     }
 
-    @Scheduled(cron = "0 31 0 * * ?")
+    @Scheduled(cron = "0 0 0 * * ?")
     public void deleteReport() {
         reportRepository.deleteProcessedOldReports();
     }

--- a/src/main/java/com/atwoz/report/application/ReportService.java
+++ b/src/main/java/com/atwoz/report/application/ReportService.java
@@ -14,6 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class ReportService {
 
+    private static final String MIDNIGHT = "0 0 0 * * ?";
+
     private final ReportRepository reportRepository;
 
     public void createReport(final ReportCreateRequest reportCreateRequest, final Long reporterId) {
@@ -33,7 +35,7 @@ public class ReportService {
                 .orElseThrow(ReportNotFoundException::new);
     }
 
-    @Scheduled(cron = "0 0 0 * * ?")
+    @Scheduled(cron = MIDNIGHT)
     public void deleteReport() {
         reportRepository.deleteProcessedOldReports();
     }

--- a/src/main/java/com/atwoz/report/application/dto/ReportCreateRequest.java
+++ b/src/main/java/com/atwoz/report/application/dto/ReportCreateRequest.java
@@ -1,0 +1,15 @@
+package com.atwoz.report.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ReportCreateRequest(
+        @NotNull(message = "프로필 id를 입력해주세요")
+        Long reportedUserId,
+
+        @NotBlank(message = "신고 유형을 입력해주세요")
+        String reportTypeCode,
+
+        String content
+) {
+}

--- a/src/main/java/com/atwoz/report/domain/Report.java
+++ b/src/main/java/com/atwoz/report/domain/Report.java
@@ -1,0 +1,77 @@
+package com.atwoz.report.domain;
+
+import com.atwoz.global.domain.BaseEntity;
+import com.atwoz.report.domain.vo.ReportResult;
+import com.atwoz.report.domain.vo.ReportType;
+import com.atwoz.report.exception.exceptions.InvalidReporterException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.validator.constraints.Length;
+
+import static com.atwoz.report.domain.vo.ReportResult.WAITING;
+
+@Getter
+@SuperBuilder
+@EqualsAndHashCode(of = "id", callSuper = false)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Report extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long reportedUserId;
+
+    @Column(nullable = false)
+    private Long reporterId;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ReportType reportType;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ReportResult reportResult;
+
+    @Length(max = 1000)
+    private String content;
+
+    public static Report createWith(final Long reportedUserId,
+                                    final Long reporterId,
+                                    final String reportType,
+                                    final String content) {
+        validateSameUser(reportedUserId, reporterId);
+        return Report.builder()
+                .reportedUserId(reportedUserId)
+                .reporterId(reporterId)
+                .reportType(ReportType.findByCode(reportType))
+                .reportResult(WAITING)
+                .content(content)
+                .build();
+    }
+
+    private static void validateSameUser(final Long reportedUserId, final Long reporterId) {
+        if (Objects.equals(reportedUserId, reporterId)) {
+            throw new InvalidReporterException();
+        }
+    }
+
+    public void updateReportResult(final String reportResult) {
+        this.reportResult = ReportResult.findByName(reportResult);
+    }
+}

--- a/src/main/java/com/atwoz/report/domain/Report.java
+++ b/src/main/java/com/atwoz/report/domain/Report.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -18,7 +19,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import org.hibernate.validator.constraints.Length;
 
 import static com.atwoz.report.domain.vo.ReportResult.WAITING;
 
@@ -48,14 +48,15 @@ public class Report extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ReportResult reportResult;
 
-    @Length(max = 1000)
+    @Lob
+    @Column(length = 1000)
     private String content;
 
     public static Report createWith(final Long reportedUserId,
                                     final Long reporterId,
                                     final String reportType,
                                     final String content) {
-        validateSameUser(reportedUserId, reporterId);
+        validateNotSameUser(reportedUserId, reporterId);
         return Report.builder()
                 .reportedUserId(reportedUserId)
                 .reporterId(reporterId)
@@ -65,7 +66,7 @@ public class Report extends BaseEntity {
                 .build();
     }
 
-    private static void validateSameUser(final Long reportedUserId, final Long reporterId) {
+    private static void validateNotSameUser(final Long reportedUserId, final Long reporterId) {
         if (Objects.equals(reportedUserId, reporterId)) {
             throw new InvalidReporterException();
         }

--- a/src/main/java/com/atwoz/report/domain/ReportRepository.java
+++ b/src/main/java/com/atwoz/report/domain/ReportRepository.java
@@ -1,0 +1,12 @@
+package com.atwoz.report.domain;
+
+import java.util.Optional;
+
+public interface ReportRepository {
+
+    Optional<Report> findById(Long id);
+
+    Report save(Report report);
+
+    void deleteProcessedOldReports();
+}

--- a/src/main/java/com/atwoz/report/domain/vo/ReportResult.java
+++ b/src/main/java/com/atwoz/report/domain/vo/ReportResult.java
@@ -1,0 +1,27 @@
+package com.atwoz.report.domain.vo;
+
+import com.atwoz.report.exception.exceptions.InvalidReportResultException;
+import java.util.Arrays;
+import lombok.Getter;
+
+@Getter
+public enum ReportResult {
+
+    WAITING("대기중"),
+    DENIED("거부"),
+    WARN("경고"),
+    BAN("정지");
+
+    private final String name;
+
+    ReportResult(final String name) {
+        this.name = name;
+    }
+
+    public static ReportResult findByName(final String name) {
+        return Arrays.stream(values())
+                .filter(reportResult -> name.equals(reportResult.name))
+                .findFirst()
+                .orElseThrow(InvalidReportResultException::new);
+    }
+}

--- a/src/main/java/com/atwoz/report/domain/vo/ReportType.java
+++ b/src/main/java/com/atwoz/report/domain/vo/ReportType.java
@@ -1,0 +1,30 @@
+package com.atwoz.report.domain.vo;
+
+import com.atwoz.report.exception.exceptions.InvalidReportTypeException;
+import java.util.Arrays;
+import lombok.Getter;
+
+@Getter
+public enum ReportType {
+
+    FAKE_PROFILE("허위 프로필", "01"),
+    EXCESSIVE_SEXUAL_EXPRESSION("과도한 성적 표현", "02"),
+    OFFENSIVE_EXPRESSION("욕설 및 불쾌함을 주는 표현", "03"),
+    INAPPROPRIATE_IMAGES("부적절한 사진", "04"),
+    PHONE_NUMBER_ON_PROFILE("프로필 내 연락처 기재", "05");
+
+    private final String reason;
+    private final String code;
+
+    ReportType(final String reason, final String code) {
+        this.reason = reason;
+        this.code = code;
+    }
+
+    public static ReportType findByCode(final String code) {
+        return Arrays.stream(values())
+                .filter(reportType -> code.equals(reportType.code))
+                .findFirst()
+                .orElseThrow(InvalidReportTypeException::new);
+    }
+}

--- a/src/main/java/com/atwoz/report/exception/ReportExceptionHandler.java
+++ b/src/main/java/com/atwoz/report/exception/ReportExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.atwoz.report.exception;
+
+import com.atwoz.report.exception.exceptions.InvalidReportResultException;
+import com.atwoz.report.exception.exceptions.InvalidReportTypeException;
+import com.atwoz.report.exception.exceptions.InvalidReporterException;
+import com.atwoz.report.exception.exceptions.ReportNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ReportExceptionHandler {
+
+    @ExceptionHandler(ReportNotFoundException.class)
+    public ResponseEntity<String> handleReportNotFoundException(final ReportNotFoundException e) {
+        return getNotFoundResponse(e);
+    }
+
+    @ExceptionHandler(InvalidReportTypeException.class)
+    public ResponseEntity<String> handleReportTypeInvalidException(final InvalidReportTypeException e) {
+        return getBadRequest(e);
+    }
+
+    @ExceptionHandler(InvalidReportResultException.class)
+    public ResponseEntity<String> handleReportResultInvalidException(final InvalidReportResultException e) {
+        return getBadRequest(e);
+    }
+
+    @ExceptionHandler(InvalidReporterException.class)
+    public ResponseEntity<String> handleReporterInvalidException(final InvalidReporterException e) {
+        return getBadRequest(e);
+    }
+
+    private ResponseEntity<String> getNotFoundResponse(final Exception e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(e.getMessage());
+    }
+
+    private ResponseEntity<String> getBadRequest(final Exception e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(e.getMessage());
+    }
+}

--- a/src/main/java/com/atwoz/report/exception/exceptions/InvalidReportResultException.java
+++ b/src/main/java/com/atwoz/report/exception/exceptions/InvalidReportResultException.java
@@ -1,0 +1,8 @@
+package com.atwoz.report.exception.exceptions;
+
+public class InvalidReportResultException extends RuntimeException {
+
+    public InvalidReportResultException() {
+        super("유효하지 않은 신고 결과입니다.");
+    }
+}

--- a/src/main/java/com/atwoz/report/exception/exceptions/InvalidReportTypeException.java
+++ b/src/main/java/com/atwoz/report/exception/exceptions/InvalidReportTypeException.java
@@ -1,0 +1,8 @@
+package com.atwoz.report.exception.exceptions;
+
+public class InvalidReportTypeException extends RuntimeException {
+
+    public InvalidReportTypeException() {
+        super("유효하지 않은 신고 사유입니다.");
+    }
+}

--- a/src/main/java/com/atwoz/report/exception/exceptions/InvalidReporterException.java
+++ b/src/main/java/com/atwoz/report/exception/exceptions/InvalidReporterException.java
@@ -1,0 +1,8 @@
+package com.atwoz.report.exception.exceptions;
+
+public class InvalidReporterException extends RuntimeException {
+
+    public InvalidReporterException() {
+        super("유효하지 않은 신고자 정보입니다");
+    }
+}

--- a/src/main/java/com/atwoz/report/exception/exceptions/ReportNotFoundException.java
+++ b/src/main/java/com/atwoz/report/exception/exceptions/ReportNotFoundException.java
@@ -1,0 +1,8 @@
+package com.atwoz.report.exception.exceptions;
+
+public class ReportNotFoundException extends RuntimeException {
+
+    public ReportNotFoundException() {
+        super("신고 정보를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/com/atwoz/report/infrastructure/ReportJdbcRepository.java
+++ b/src/main/java/com/atwoz/report/infrastructure/ReportJdbcRepository.java
@@ -1,0 +1,20 @@
+package com.atwoz.report.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class ReportJdbcRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public void deleteProcessedOldReports() {
+        String sql = "DELETE FROM Report"
+                + " WHERE updated_at < TIMESTAMPADD(DAY, -30, CURRENT_DATE)" +
+                " AND report_result <> 'WAITING'";
+
+        jdbcTemplate.update(sql);
+    }
+}

--- a/src/main/java/com/atwoz/report/infrastructure/ReportJpaRepository.java
+++ b/src/main/java/com/atwoz/report/infrastructure/ReportJpaRepository.java
@@ -1,0 +1,7 @@
+package com.atwoz.report.infrastructure;
+
+import com.atwoz.report.domain.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportJpaRepository extends JpaRepository<Report, Long> {
+}

--- a/src/main/java/com/atwoz/report/infrastructure/ReportRepositoryImpl.java
+++ b/src/main/java/com/atwoz/report/infrastructure/ReportRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.atwoz.report.infrastructure;
+
+import com.atwoz.report.domain.Report;
+import com.atwoz.report.domain.ReportRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class ReportRepositoryImpl implements ReportRepository {
+
+    private final ReportJdbcRepository reportJdbcRepository;
+    private final ReportJpaRepository reportJpaRepository;
+
+    @Override
+    public Optional<Report> findById(final Long id) {
+        return reportJpaRepository.findById(id);
+    }
+
+    @Override
+    public Report save(final Report report) {
+        return reportJpaRepository.save(report);
+    }
+
+    @Override
+    public void deleteProcessedOldReports() {
+        reportJdbcRepository.deleteProcessedOldReports();
+    }
+}

--- a/src/main/java/com/atwoz/report/ui/ReportController.java
+++ b/src/main/java/com/atwoz/report/ui/ReportController.java
@@ -1,0 +1,30 @@
+package com.atwoz.report.ui;
+
+
+import com.atwoz.member.ui.auth.support.auth.AuthMember;
+import com.atwoz.report.application.ReportService;
+import com.atwoz.report.application.dto.ReportCreateRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/reports")
+@RestController
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @PostMapping
+    public ResponseEntity<Void> createReport(@RequestBody @Valid final ReportCreateRequest reportCreateRequest,
+                                             @AuthMember final Long reporterId) {
+        reportService.createReport(reportCreateRequest, reporterId);
+
+        return ResponseEntity.ok()
+                .build();
+    }
+}

--- a/src/main/java/com/atwoz/report/ui/ReportController.java
+++ b/src/main/java/com/atwoz/report/ui/ReportController.java
@@ -1,6 +1,5 @@
 package com.atwoz.report.ui;
 
-
 import com.atwoz.member.ui.auth.support.auth.AuthMember;
 import com.atwoz.report.application.ReportService;
 import com.atwoz.report.application.dto.ReportCreateRequest;

--- a/src/test/java/com/atwoz/config/TestAuditingTestConfig.java
+++ b/src/test/java/com/atwoz/config/TestAuditingTestConfig.java
@@ -1,0 +1,26 @@
+package com.atwoz.config;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.auditing.AuditingHandler;
+
+@TestConfiguration
+public class TestAuditingTestConfig {
+
+    private static final int THIRTY_ONE = 31;
+
+    @Autowired
+    private AuditingHandler auditingHandler;
+
+    @Bean
+    public AuditingHandler customAuditingHandler() {
+        LocalDateTime thirtyOneDaysAgo = LocalDateTime.now()
+                .minusDays(THIRTY_ONE);
+        auditingHandler.setDateTimeProvider(() -> Optional.of(thirtyOneDaysAgo));
+
+        return auditingHandler;
+    }
+}

--- a/src/test/java/com/atwoz/config/TestAuditingTestConfig.java
+++ b/src/test/java/com/atwoz/config/TestAuditingTestConfig.java
@@ -10,16 +10,16 @@ import org.springframework.data.auditing.AuditingHandler;
 @TestConfiguration
 public class TestAuditingTestConfig {
 
-    private static final int THIRTY_ONE = 31;
+    private static final int DELETION_THRESHOLD = 31;
 
     @Autowired
     private AuditingHandler auditingHandler;
 
     @Bean
     public AuditingHandler customAuditingHandler() {
-        LocalDateTime thirtyOneDaysAgo = LocalDateTime.now()
-                .minusDays(THIRTY_ONE);
-        auditingHandler.setDateTimeProvider(() -> Optional.of(thirtyOneDaysAgo));
+        LocalDateTime pastDate = LocalDateTime.now()
+                .minusDays(DELETION_THRESHOLD);
+        auditingHandler.setDateTimeProvider(() -> Optional.of(pastDate));
 
         return auditingHandler;
     }

--- a/src/test/java/com/atwoz/helper/MockBeanInjection.java
+++ b/src/test/java/com/atwoz/helper/MockBeanInjection.java
@@ -15,6 +15,7 @@ import com.atwoz.mission.application.membermission.MemberMissionsQueryService;
 import com.atwoz.mission.application.membermission.MemberMissionsService;
 import com.atwoz.mission.application.mission.MissionQueryService;
 import com.atwoz.mission.application.mission.MissionService;
+import com.atwoz.report.application.ReportService;
 import com.atwoz.survey.application.membersurvey.MemberSurveysQueryService;
 import com.atwoz.survey.application.membersurvey.MemberSurveysService;
 import com.atwoz.survey.application.survey.SurveyService;
@@ -77,4 +78,7 @@ public class MockBeanInjection {
 
     @MockBean
     protected MemberQueryService memberQueryService;
+
+    @MockBean
+    protected ReportService reportService;
 }

--- a/src/test/java/com/atwoz/report/application/ReportServiceTest.java
+++ b/src/test/java/com/atwoz/report/application/ReportServiceTest.java
@@ -3,6 +3,7 @@ package com.atwoz.report.application;
 import com.atwoz.report.application.dto.ReportCreateRequest;
 import com.atwoz.report.domain.Report;
 import com.atwoz.report.domain.ReportRepository;
+import com.atwoz.report.domain.vo.ReportResult;
 import com.atwoz.report.exception.exceptions.ReportNotFoundException;
 import com.atwoz.report.infrastructure.ReportFakeRepository;
 import java.util.Optional;
@@ -77,7 +78,8 @@ class ReportServiceTest {
             reportService.updateReportResult(reportResult, savedReport.getId());
 
             // then
-            assertThat(savedReport.getReportResult().getName()).isEqualTo(reportResult);
+            ReportResult savedReportResult = savedReport.getReportResult();
+            assertThat(savedReportResult.getName()).isEqualTo(reportResult);
         }
     }
 

--- a/src/test/java/com/atwoz/report/application/ReportServiceTest.java
+++ b/src/test/java/com/atwoz/report/application/ReportServiceTest.java
@@ -1,0 +1,102 @@
+package com.atwoz.report.application;
+
+import com.atwoz.report.application.dto.ReportCreateRequest;
+import com.atwoz.report.domain.Report;
+import com.atwoz.report.domain.ReportRepository;
+import com.atwoz.report.exception.exceptions.ReportNotFoundException;
+import com.atwoz.report.infrastructure.ReportFakeRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static com.atwoz.report.domain.vo.ReportResult.BAN;
+import static com.atwoz.report.fixture.ReportCreateRequestFixture.신고_요청_생성;
+import static com.atwoz.report.fixture.ReportFixture.신고_생성;
+import static com.atwoz.report.fixture.ReportFixture.처리된지_31일된_신고_생성;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class ReportServiceTest {
+
+    private ReportService reportService;
+    private ReportRepository reportRepository;
+
+    @BeforeEach
+    void setup() {
+        reportRepository = new ReportFakeRepository();
+        reportService = new ReportService(reportRepository);
+    }
+
+    @Test
+    void 불건전한_유저를_신고한다() {
+        // given
+        ReportCreateRequest reportCreateRequest = 신고_요청_생성();
+        Long reportId = 1L;
+        Long reporterId = 2L;
+
+        // when
+        reportService.createReport(reportCreateRequest, reporterId);
+
+        // then
+        Optional<Report> foundReport = reportRepository.findById(reportId);
+        assertSoftly(softly -> {
+            softly.assertThat(foundReport).isPresent();
+            Report report = foundReport.get();
+            softly.assertThat(report.getId()).isEqualTo(reportId);
+            softly.assertThat(report.getReporterId()).isEqualTo(reporterId);
+        });
+    }
+
+    @Nested
+    class 신고_결과_변경 {
+
+        @Test
+        void 존재하지_않는_신고일_경우_예외가_발생한다() {
+            // given
+            Long notExistReportId = 1L;
+            String reportResult = BAN.getName();
+
+            // when & then
+            assertThatThrownBy(() -> reportService.updateReportResult(reportResult, notExistReportId))
+                    .isInstanceOf(ReportNotFoundException.class);
+        }
+
+        @Test
+        void 접수된_신고의_결과를_변경한다() {
+            // given
+            Report savedReport = reportRepository.save(신고_생성());
+            String reportResult = BAN.getName();
+
+            // when
+            reportService.updateReportResult(reportResult, savedReport.getId());
+
+            // then
+            assertThat(savedReport.getReportResult().getName()).isEqualTo(reportResult);
+        }
+    }
+
+    @Test
+    void 처리된지_30일_이상_지난_신고는_삭제된다() {
+        // given
+        reportRepository.save(신고_생성());
+        reportRepository.save(처리된지_31일된_신고_생성());
+
+        // when
+        reportService.deleteReport();
+
+        // then
+        Optional<Report> foundReport = reportRepository.findById(1L);
+        Optional<Report> processedOldReport = reportRepository.findById(2L);
+
+        assertSoftly(softly -> {
+            softly.assertThat(foundReport).isPresent();
+            softly.assertThat(processedOldReport).isNotPresent();
+        });
+    }
+}

--- a/src/test/java/com/atwoz/report/domain/ReportTest.java
+++ b/src/test/java/com/atwoz/report/domain/ReportTest.java
@@ -1,0 +1,69 @@
+package com.atwoz.report.domain;
+
+import com.atwoz.report.exception.exceptions.InvalidReporterException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static com.atwoz.report.domain.vo.ReportResult.BAN;
+import static com.atwoz.report.domain.vo.ReportType.FAKE_PROFILE;
+import static com.atwoz.report.fixture.ReportFixture.신고_생성;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class ReportTest {
+
+    @Nested
+    class 신고_생성 {
+
+        @Test
+        void 신고를_생성한다() {
+            // given
+            Long profileOwnerId = 1L;
+            Long reporterId = 2L;
+            String reportType = FAKE_PROFILE.getCode();
+            String content = "사진을 도용했어요";
+
+            // when
+            Report report = Report.createWith(profileOwnerId, reporterId, reportType, content);
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(report.getReportedUserId()).isEqualTo(profileOwnerId);
+                softly.assertThat(report.getReporterId()).isEqualTo(reporterId);
+                softly.assertThat(report.getReportType().getCode()).isEqualTo(reportType);
+                softly.assertThat(report.getContent()).isEqualTo(content);
+            });
+        }
+
+        @Test
+        void 신고자와_신고당한자의_정보가_일치하면_예외가_발생한다() {
+            // given
+            Long profileOwnerId = 1L;
+            Long reporterId = 1L;
+            String reportType = FAKE_PROFILE.getCode();
+            String content = "사진을 도용했어요";
+
+            // when & then
+            assertThatThrownBy(() -> Report.createWith(profileOwnerId, reporterId, reportType, content))
+                    .isInstanceOf(InvalidReporterException.class);
+        }
+    }
+
+    @Test
+    void 신고_결과를_변경한다() {
+        // given
+        Report report = 신고_생성();
+        String reportResult = BAN.getName();
+
+        // when
+        report.updateReportResult(reportResult);
+
+        // then
+        assertThat(report.getReportResult().getName()).isEqualTo(reportResult);
+    }
+}

--- a/src/test/java/com/atwoz/report/domain/vo/ReportResultTest.java
+++ b/src/test/java/com/atwoz/report/domain/vo/ReportResultTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static com.atwoz.report.domain.vo.ReportResult.BAN;
-import static com.atwoz.report.domain.vo.ReportResult.findByName;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -19,12 +18,12 @@ class ReportResultTest {
     class ReportResult_조회 {
 
         @Test
-        void 신고_결과_정보가_유효하지_않으면_예외가_밠생한다() {
-            //  given
+        void 신고_결과_정보가_유효하지_않으면_예외가_발생한다() {
+            // given
             String invalidReportResult = "invalid report result";
 
-            // when
-            assertThatThrownBy(() -> findByName(invalidReportResult))
+            // when & then
+            assertThatThrownBy(() -> ReportResult.findByName(invalidReportResult))
                     .isInstanceOf(InvalidReportResultException.class);
         }
 
@@ -33,8 +32,8 @@ class ReportResultTest {
             // given
             String validReportResult = BAN.getName();
 
-            // When
-            ReportResult foundReportResult = findByName(validReportResult);
+            // when
+            ReportResult foundReportResult = ReportResult.findByName(validReportResult);
 
             // then
             assertThat(foundReportResult.getName()).isEqualTo(validReportResult);

--- a/src/test/java/com/atwoz/report/domain/vo/ReportResultTest.java
+++ b/src/test/java/com/atwoz/report/domain/vo/ReportResultTest.java
@@ -1,0 +1,43 @@
+package com.atwoz.report.domain.vo;
+
+import com.atwoz.report.exception.exceptions.InvalidReportResultException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static com.atwoz.report.domain.vo.ReportResult.BAN;
+import static com.atwoz.report.domain.vo.ReportResult.findByName;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class ReportResultTest {
+
+    @Nested
+    class ReportResult_조회 {
+
+        @Test
+        void 신고_결과_정보가_유효하지_않으면_예외가_밠생한다() {
+            //  given
+            String invalidReportResult = "invalid report result";
+
+            // when
+            assertThatThrownBy(() -> findByName(invalidReportResult))
+                    .isInstanceOf(InvalidReportResultException.class);
+        }
+
+        @Test
+        void 신고_결과_정보가_유효하면_ReportResult을_찾아_반환한다() {
+            // given
+            String validReportResult = BAN.getName();
+
+            // When
+            ReportResult foundReportResult = findByName(validReportResult);
+
+            // then
+            assertThat(foundReportResult.getName()).isEqualTo(validReportResult);
+        }
+    }
+}

--- a/src/test/java/com/atwoz/report/domain/vo/ReportTypeTest.java
+++ b/src/test/java/com/atwoz/report/domain/vo/ReportTypeTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static com.atwoz.report.domain.vo.ReportType.FAKE_PROFILE;
-import static com.atwoz.report.domain.vo.ReportType.findByCode;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -24,7 +23,7 @@ class ReportTypeTest {
             String invalidReportType = "invalid report type";
 
             // when
-            assertThatThrownBy(() -> findByCode(invalidReportType))
+            assertThatThrownBy(() -> ReportType.findByCode(invalidReportType))
                     .isInstanceOf(InvalidReportTypeException.class);
         }
 
@@ -34,7 +33,7 @@ class ReportTypeTest {
             String validReportType = FAKE_PROFILE.getCode();
 
             // When
-            ReportType foundReportType = findByCode(validReportType);
+            ReportType foundReportType = ReportType.findByCode(validReportType);
 
             // then
             assertThat(foundReportType.getCode()).isEqualTo(validReportType);

--- a/src/test/java/com/atwoz/report/domain/vo/ReportTypeTest.java
+++ b/src/test/java/com/atwoz/report/domain/vo/ReportTypeTest.java
@@ -1,0 +1,43 @@
+package com.atwoz.report.domain.vo;
+
+import com.atwoz.report.exception.exceptions.InvalidReportTypeException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static com.atwoz.report.domain.vo.ReportType.FAKE_PROFILE;
+import static com.atwoz.report.domain.vo.ReportType.findByCode;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class ReportTypeTest {
+
+    @Nested
+    class ReportType_조회{
+
+        @Test
+        void 신고_유형_정보가_유효하지_않으면_예외가_밠생한다() {
+            //  given
+            String invalidReportType = "invalid report type";
+
+            // when
+            assertThatThrownBy(() -> findByCode(invalidReportType))
+                    .isInstanceOf(InvalidReportTypeException.class);
+        }
+
+        @Test
+        void 신고_유형_정보가_유효하면_ReportType을_찾아_반환한다() {
+            // given
+            String validReportType = FAKE_PROFILE.getCode();
+
+            // When
+            ReportType foundReportType = findByCode(validReportType);
+
+            // then
+            assertThat(foundReportType.getCode()).isEqualTo(validReportType);
+        }
+    }
+}

--- a/src/test/java/com/atwoz/report/domain/vo/ReportTypeTest.java
+++ b/src/test/java/com/atwoz/report/domain/vo/ReportTypeTest.java
@@ -18,11 +18,11 @@ class ReportTypeTest {
     class ReportType_조회{
 
         @Test
-        void 신고_유형_정보가_유효하지_않으면_예외가_밠생한다() {
-            //  given
+        void 신고_유형_정보가_유효하지_않으면_예외가_발생한다() {
+            // given
             String invalidReportType = "invalid report type";
 
-            // when
+            // when & then
             assertThatThrownBy(() -> ReportType.findByCode(invalidReportType))
                     .isInstanceOf(InvalidReportTypeException.class);
         }
@@ -32,7 +32,7 @@ class ReportTypeTest {
             // given
             String validReportType = FAKE_PROFILE.getCode();
 
-            // When
+            // when
             ReportType foundReportType = ReportType.findByCode(validReportType);
 
             // then

--- a/src/test/java/com/atwoz/report/fixture/ReportCreateRequestFixture.java
+++ b/src/test/java/com/atwoz/report/fixture/ReportCreateRequestFixture.java
@@ -1,0 +1,13 @@
+package com.atwoz.report.fixture;
+
+import com.atwoz.report.application.dto.ReportCreateRequest;
+
+import static com.atwoz.report.domain.vo.ReportType.FAKE_PROFILE;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class ReportCreateRequestFixture {
+
+    public static ReportCreateRequest 신고_요청_생성() {
+        return new ReportCreateRequest(1L, FAKE_PROFILE.getCode(), "사진을 도용했어요!");
+    }
+}

--- a/src/test/java/com/atwoz/report/fixture/ReportFixture.java
+++ b/src/test/java/com/atwoz/report/fixture/ReportFixture.java
@@ -1,0 +1,53 @@
+package com.atwoz.report.fixture;
+
+import com.atwoz.report.domain.Report;
+import java.time.LocalDateTime;
+
+import static com.atwoz.report.domain.vo.ReportResult.BAN;
+import static com.atwoz.report.domain.vo.ReportResult.WAITING;
+import static com.atwoz.report.domain.vo.ReportType.FAKE_PROFILE;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class ReportFixture {
+
+    public static Report 신고_생성() {
+
+        return Report.builder()
+                .reportedUserId(1L)
+                .reporterId(2L)
+                .reportType(FAKE_PROFILE)
+                .reportResult(WAITING)
+                .content("사진을 도용했어요!")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static Report 처리된_신고_생성() {
+
+        return Report.builder()
+                .reportedUserId(1L)
+                .reporterId(2L)
+                .reportType(FAKE_PROFILE)
+                .reportResult(BAN)
+                .content("사진을 도용했어요!")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static Report 처리된지_31일된_신고_생성() {
+
+        return Report.builder()
+                .reportedUserId(1L)
+                .reporterId(2L)
+                .reportType(FAKE_PROFILE)
+                .reportResult(BAN)
+                .content("사진을 도용했어요!")
+                .createdAt(LocalDateTime.now()
+                        .minusDays(32))
+                .updatedAt(LocalDateTime.now()
+                        .minusDays(31))
+                .build();
+    }
+}

--- a/src/test/java/com/atwoz/report/fixture/ReportFixture.java
+++ b/src/test/java/com/atwoz/report/fixture/ReportFixture.java
@@ -10,44 +10,46 @@ import static com.atwoz.report.domain.vo.ReportType.FAKE_PROFILE;
 @SuppressWarnings("NonAsciiCharacters")
 public class ReportFixture {
 
-    public static Report 신고_생성() {
+    private static final int DELETION_THRESHOLD = 31;
+    private static final Long REPORTED_USER_ID = 1L;
+    private static final Long REPORTER_ID = 2L;
+    private static final String REPORT_CONTENT = "사진을 도용했어요!";
 
+    public static Report 신고_생성() {
         return Report.builder()
-                .reportedUserId(1L)
-                .reporterId(2L)
+                .reportedUserId(REPORTED_USER_ID)
+                .reporterId(REPORTER_ID)
                 .reportType(FAKE_PROFILE)
                 .reportResult(WAITING)
-                .content("사진을 도용했어요!")
+                .content(REPORT_CONTENT)
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
                 .build();
     }
 
     public static Report 처리된_신고_생성() {
-
         return Report.builder()
-                .reportedUserId(1L)
-                .reporterId(2L)
+                .reportedUserId(REPORTED_USER_ID)
+                .reporterId(REPORTER_ID)
                 .reportType(FAKE_PROFILE)
                 .reportResult(BAN)
-                .content("사진을 도용했어요!")
+                .content(REPORT_CONTENT)
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
                 .build();
     }
 
     public static Report 처리된지_31일된_신고_생성() {
-
         return Report.builder()
-                .reportedUserId(1L)
-                .reporterId(2L)
+                .reportedUserId(REPORTED_USER_ID)
+                .reporterId(REPORTER_ID)
                 .reportType(FAKE_PROFILE)
                 .reportResult(BAN)
-                .content("사진을 도용했어요!")
+                .content(REPORT_CONTENT)
                 .createdAt(LocalDateTime.now()
-                        .minusDays(32))
+                        .minusDays(DELETION_THRESHOLD))
                 .updatedAt(LocalDateTime.now()
-                        .minusDays(31))
+                        .minusDays(DELETION_THRESHOLD))
                 .build();
     }
 }

--- a/src/test/java/com/atwoz/report/infrastructure/ReportFakeRepository.java
+++ b/src/test/java/com/atwoz/report/infrastructure/ReportFakeRepository.java
@@ -9,6 +9,8 @@ import java.util.Optional;
 
 public class ReportFakeRepository implements ReportRepository {
 
+    private static final int DELETION_THRESHOLD_DATE = 30;
+
     private final Map<Long, Report> map = new HashMap<>();
     private Long id = 1L;
 
@@ -41,7 +43,7 @@ public class ReportFakeRepository implements ReportRepository {
 
     private boolean isProcessedOldReport(final Report report) {
         LocalDateTime thirtyDaysAgo = LocalDateTime.now()
-                .minusDays(30);
+                .minusDays(DELETION_THRESHOLD_DATE);
 
         return report.getUpdatedAt()
                 .isBefore(thirtyDaysAgo);

--- a/src/test/java/com/atwoz/report/infrastructure/ReportFakeRepository.java
+++ b/src/test/java/com/atwoz/report/infrastructure/ReportFakeRepository.java
@@ -1,0 +1,49 @@
+package com.atwoz.report.infrastructure;
+
+import com.atwoz.report.domain.Report;
+import com.atwoz.report.domain.ReportRepository;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class ReportFakeRepository implements ReportRepository {
+
+    private final Map<Long, Report> map = new HashMap<>();
+    private Long id = 1L;
+
+    @Override
+    public Optional<Report> findById(final Long id) {
+        return Optional.ofNullable(map.get(id));
+    }
+
+    @Override
+    public Report save(final Report report) {
+        Report savedReport = Report.builder()
+                .id(id)
+                .reportedUserId(report.getReportedUserId())
+                .reporterId(report.getReporterId())
+                .reportType(report.getReportType())
+                .content(report.getContent())
+                .createdAt(report.getCreatedAt())
+                .updatedAt(report.getUpdatedAt())
+                .build();
+        map.put(id, savedReport);
+
+        return map.get(id++);
+    }
+
+    @Override
+    public void deleteProcessedOldReports() {
+        map.entrySet()
+                .removeIf(entry -> isProcessedOldReport(entry.getValue()));
+    }
+
+    private boolean isProcessedOldReport(final Report report) {
+        LocalDateTime thirtyDaysAgo = LocalDateTime.now()
+                .minusDays(30);
+
+        return report.getUpdatedAt()
+                .isBefore(thirtyDaysAgo);
+    }
+}

--- a/src/test/java/com/atwoz/report/infrastructure/ReportJdbcRepositoryTest.java
+++ b/src/test/java/com/atwoz/report/infrastructure/ReportJdbcRepositoryTest.java
@@ -1,0 +1,41 @@
+package com.atwoz.report.infrastructure;
+
+import com.atwoz.config.TestAuditingTestConfig;
+import com.atwoz.helper.IntegrationHelper;
+import com.atwoz.report.domain.Report;
+import com.atwoz.report.domain.ReportRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import static com.atwoz.report.fixture.ReportFixture.처리된_신고_생성;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@Import(TestAuditingTestConfig.class)
+class ReportJdbcRepositoryTest extends IntegrationHelper {
+
+    @Autowired
+    private ReportJdbcRepository reportJdbcRepository;
+
+    @Autowired
+    private ReportRepository reportRepository;
+
+    @Test
+    void 처리된지_30일이_지난_신고는_삭제된다() {
+        // given
+        Report report = 처리된_신고_생성();
+        reportRepository.save(report);
+
+        // when
+        reportJdbcRepository.deleteProcessedOldReports();
+
+        // then
+        Optional<Report> foundReport = reportRepository.findById(1L);
+        assertThat(foundReport).isEmpty();
+    }
+}

--- a/src/test/java/com/atwoz/report/infrastructure/ReportJpaRepositoryTest.java
+++ b/src/test/java/com/atwoz/report/infrastructure/ReportJpaRepositoryTest.java
@@ -45,7 +45,9 @@ class ReportJpaRepositoryTest {
         assertSoftly(softly -> {
             softly.assertThat(foundReport).isPresent();
             Report report = foundReport.get();
-            softly.assertThat(report).usingRecursiveComparison().isEqualTo(createdReport);
+            softly.assertThat(report)
+                    .usingRecursiveComparison()
+                    .isEqualTo(createdReport);
         });
     }
 }

--- a/src/test/java/com/atwoz/report/infrastructure/ReportJpaRepositoryTest.java
+++ b/src/test/java/com/atwoz/report/infrastructure/ReportJpaRepositoryTest.java
@@ -1,0 +1,54 @@
+package com.atwoz.report.infrastructure;
+
+import com.atwoz.config.TestAuditingTestConfig;
+import com.atwoz.report.domain.Report;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import static com.atwoz.report.fixture.ReportFixture.신고_생성;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@DataJpaTest
+@Import(TestAuditingTestConfig.class)
+class ReportJpaRepositoryTest {
+
+    @Autowired
+    private ReportJpaRepository reportJpaRepository;
+
+    @Test
+    void 신고_저장() {
+        // given
+        Report createdReport = 신고_생성();
+
+        // when
+        Report savedReport = reportJpaRepository.save(createdReport);
+
+        // then
+        assertThat(savedReport).usingRecursiveComparison().isEqualTo(createdReport);
+    }
+
+    @Test
+    void 신고_이이디_값으로_단건_조회() {
+        // given
+        Report createdReport = 신고_생성();
+        reportJpaRepository.save(createdReport);
+
+        // when
+        Optional<Report> foundReport = reportJpaRepository.findById(createdReport.getId());
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(foundReport).isPresent();
+            Report report = foundReport.get();
+            softly.assertThat(report).usingRecursiveComparison().isEqualTo(createdReport);
+        });
+    }
+}

--- a/src/test/java/com/atwoz/report/infrastructure/ReportJpaRepositoryTest.java
+++ b/src/test/java/com/atwoz/report/infrastructure/ReportJpaRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.atwoz.report.infrastructure;
 
-import com.atwoz.config.TestAuditingTestConfig;
 import com.atwoz.report.domain.Report;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -8,7 +7,6 @@ import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
 import static com.atwoz.report.fixture.ReportFixture.신고_생성;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,7 +15,6 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 @DataJpaTest
-@Import(TestAuditingTestConfig.class)
 class ReportJpaRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/atwoz/report/ui/ReportControllerAcceptanceFixture.java
+++ b/src/test/java/com/atwoz/report/ui/ReportControllerAcceptanceFixture.java
@@ -38,7 +38,7 @@ public class ReportControllerAcceptanceFixture extends IntegrationHelper {
     }
 
     protected ReportCreateRequest 신고_요청서_요청() {
-        return new ReportCreateRequest(1L, FAKE_PROFILE.getCode(), "사진 도용했어요");
+        return new ReportCreateRequest(2L, FAKE_PROFILE.getCode(), "사진 도용했어요");
     }
 
     protected ExtractableResponse<Response> 신고_생성_요청(final String uri, final String token,

--- a/src/test/java/com/atwoz/report/ui/ReportControllerAcceptanceFixture.java
+++ b/src/test/java/com/atwoz/report/ui/ReportControllerAcceptanceFixture.java
@@ -1,0 +1,59 @@
+package com.atwoz.report.ui;
+
+import com.atwoz.helper.IntegrationHelper;
+import com.atwoz.member.domain.auth.TokenProvider;
+import com.atwoz.member.domain.member.Member;
+import com.atwoz.member.domain.member.MemberRepository;
+import com.atwoz.report.application.dto.ReportCreateRequest;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import static com.atwoz.member.fixture.MemberFixture.일반_유저_생성;
+import static com.atwoz.report.domain.vo.ReportType.FAKE_PROFILE;
+import static io.restassured.http.ContentType.JSON;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+public class ReportControllerAcceptanceFixture extends IntegrationHelper {
+
+    @Autowired
+    protected MemberRepository memberRepository;
+
+    @Autowired
+    protected TokenProvider tokenProvider;
+
+    protected Member 회원_생성() {
+        return memberRepository.save(일반_유저_생성());
+    }
+
+    protected String 토큰_생성(final Member member) {
+        return tokenProvider.createTokenWithId(member.getId());
+    }
+
+    protected ReportCreateRequest 신고_요청서_요청() {
+        return new ReportCreateRequest(1L, FAKE_PROFILE.getCode(), "사진 도용했어요");
+    }
+
+    protected ExtractableResponse<Response> 신고_생성_요청(final String uri, final String token,
+                                                     final ReportCreateRequest reportCreateRequest) {
+        return RestAssured.given().log().all()
+                .header(AUTHORIZATION, "Bearer " + token)
+                .contentType(JSON)
+                .body(reportCreateRequest)
+                .when()
+                .post(uri)
+                .then()
+                .extract();
+    }
+
+    protected void 신고_생성_요청_검증(final ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+}

--- a/src/test/java/com/atwoz/report/ui/ReportControllerAcceptanceTest.java
+++ b/src/test/java/com/atwoz/report/ui/ReportControllerAcceptanceTest.java
@@ -1,0 +1,32 @@
+package com.atwoz.report.ui;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class ReportControllerAcceptanceTest extends ReportControllerAcceptanceFixture {
+
+    private static final String 신고_URI = "/api/reports";
+
+    private String 토큰;
+
+    @BeforeEach
+    void setup() {
+        토큰 = 토큰_생성(회원_생성());
+    }
+
+    @Test
+    void 불건전한_유저를_신고한다() {
+        // given
+        var 신고_요청서 = 신고_요청서_요청();
+
+        // when
+        var 신고_생성_요청_결과 = 신고_생성_요청(신고_URI, 토큰, 신고_요청서);
+
+        // then
+        신고_생성_요청_검증(신고_생성_요청_결과);
+    }
+}

--- a/src/test/java/com/atwoz/report/ui/ReportControllerWebMvcTest.java
+++ b/src/test/java/com/atwoz/report/ui/ReportControllerWebMvcTest.java
@@ -1,0 +1,60 @@
+package com.atwoz.report.ui;
+
+import com.atwoz.helper.MockBeanInjection;
+import com.atwoz.report.application.dto.ReportCreateRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.atwoz.helper.RestDocsHelper.customDocument;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@AutoConfigureRestDocs
+@WebMvcTest(ReportController.class)
+class ReportControllerWebMvcTest extends MockBeanInjection {
+
+    private static final String BEARER_TOKEN = "Bearer token";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void 불건전한_유저를_신고한다() throws Exception {
+        // given
+        ReportCreateRequest reportCreateRequest = new ReportCreateRequest(1L, "부적절한 사진", "사진 도용했어요");
+
+        //when & then
+        mockMvc.perform(post("/api/reports")
+                        .header(AUTHORIZATION, BEARER_TOKEN)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(reportCreateRequest)))
+                .andExpect(status().isOk())
+                .andDo(customDocument("불건전한_유저_신고",
+                        requestHeaders(
+                                headerWithName(AUTHORIZATION).description("유저 토큰 정보")
+                        ),
+                        requestFields(
+                                fieldWithPath("reportedUserId").description("불건전한 프로필의 유저 id"),
+                                fieldWithPath("reportTypeCode").description("신고 사유"),
+                                fieldWithPath("content").description("상세 내용"))
+                ));
+
+    }
+}

--- a/src/test/java/com/atwoz/report/ui/ReportControllerWebMvcTest.java
+++ b/src/test/java/com/atwoz/report/ui/ReportControllerWebMvcTest.java
@@ -55,6 +55,5 @@ class ReportControllerWebMvcTest extends MockBeanInjection {
                                 fieldWithPath("reportTypeCode").description("신고 사유"),
                                 fieldWithPath("content").description("상세 내용"))
                 ));
-
     }
 }


### PR DESCRIPTION
## 📄 Summary

 신고 기능 구현을 완료했습니다.


## 🙋🏻 More

- 신고 처리가 완료된 신고는 30일 이상 지나면 데이터베이스에서 삭제되도록 구현했습니다. (삭제 쿼리는 매일 자정에 실행됩니다.)
- 위의 기능을 테스트하기 위해 엔티티 생성시 생성 시점을 특정 일자(30일 이상)로 조작하기 위하여 TestAuditingTestConfig를 추가하였습니다. 해당 클래스에는 엔티티의 정보를 auditing하기 위해 빈으로 등록된 AuditingHandler의 dateTimeProvider를 커스텀하여 엔티티 생성시 생성일자를 원하는 대로 엔티티에 저장될 수 있도록하여 해당 기능을 테스트가 가능하도록 했습니다.


close #26