### PR TITLE
refactor: CORS 설정 변경 (4차)

### DIFF
--- a/src/main/java/com/atwoz/global/config/filter/CorsCustomFilter.java
+++ b/src/main/java/com/atwoz/global/config/filter/CorsCustomFilter.java
@@ -23,7 +23,6 @@ public class CorsCustomFilter extends OncePerRequestFilter {
         response.setHeader("Access-Control-Max-Age", "3600");
         response.setHeader("Access-Control-Allow-Headers",
                 "Origin, X-Requested-With, Content-Type, Accept, Authorization, x-xsrf-token");
-        response.setHeader("Access-Control-Expose-Headers", "Set-Cookie");
         ContentCachingRequestWrapper contentCachingRequestWrapper = new ContentCachingRequestWrapper(request);
         ContentCachingResponseWrapper contentCachingResponseWrapper = new ContentCachingResponseWrapper(response);
 


### PR DESCRIPTION
## 📄 Summary

`Access-Control-Expose-Headers`에 허용되지 않는 cookie 설정을 제거했습니다.

close #69